### PR TITLE
[🐸 Frogbot] Update version of protobufjs to 6.11.3

### DIFF
--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "lodash": "4.17.19",
         "minimist": "1.2.5",
-        "protobufjs": "6.11.2",
+        "protobufjs": "^6.11.3",
         "vconsole": "^3.15.0"
       }
     },
@@ -132,9 +132,9 @@
       "integrity": "sha512-M/O/4rF2h776hV7qGMZUH3utZLO/jK7p8rnNgGkjKUw8zCGjRQPxB8z6+5l8+VjRUQ3dNYu4vjqXYLr+U8ZVNA=="
     },
     "node_modules/protobufjs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",

--- a/npm/package.json
+++ b/npm/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "lodash": "4.17.19",
     "minimist": "1.2.5",
-    "vconsole": "^3.15.0",
-    "protobufjs": "6.11.2"
+    "protobufjs": "^6.11.3",
+    "vconsole": "^3.15.0"
   }
 }


### PR DESCRIPTION

- **Severity:** 🔥 High
- **Contextual Analysis:** Applicable
- **Package Name:** protobufjs
- **Current Version:** 6.11.2
- **Fixed Version:** [6.11.3]
- **CVEs:** CVE-2022-25878

**Description:**

[Protocol Buffers](https://developers.google.com/protocol-buffers) or "protobufs" are a language-neutral, platform-neutral, extensible way of serializing structured data. [protobuf.js](https://www.npmjs.com/package/protobufjs) is a JavaScript library that allows creating and consuming protobufs.

Multiple prototype pollution vulnerabilities were detected in the `protobuf.js` library. Namely these can occur when:
1. `util.setProperty` receives untrusted input in arguments 2 & 3 -
```js
protobuf.util.setProperty({}, "__proto__.someprop", "somevalue");
```

2. `ReflectionObject.setParsedOption` receives untrusted input in arguments 2 & 3
```js
let obj = new protobuf.ReflectionObject("Test")
obj.setParsedOption({}, "somevalue", "__proto__.someprop");
```

3. `parse` receives untrusted input (an untrusted  `.proto` definition) -
```js
let p = `option (foo).__proto__.someprop= "somevalue";` 
protobuf.parse(p)
```

4. `load` receives an untrusted  `.proto`  file -
```js
protobuf.load("/path/to/untrusted.proto", function(err, root) { ... });
```

**Remediation:**
##### Development mitigations

Add the `Object.freeze(Object.prototype);` directive once at the beginning of your main JS source code file (ex. `index.js`), preferably after all your `require` directives. This will prevent any changes to the prototype object, thus completely negating prototype pollution attacks.
