### PR TITLE
[🐸 Frogbot] Update dependencies versions

### DIFF
--- a/maven/multi1/pom.xml
+++ b/maven/multi1/pom.xml
@@ -52,13 +52,13 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-email</artifactId>
-            <version>1.1</version>
+            <version>1.5</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>1.5.1</version>
+            <version>3.0.16</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet.jsp</groupId>
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.4</version>
+            <version>2.7</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>


### PR DESCRIPTION

## Summary

<div align="center">

| SEVERITY                | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                   | FIXED VERSIONS                       |
| :---------------------: | :----------------------------------: | :-----------------------------------: | :---------------------------------: | 
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/criticalSeverity.png)<br>Critical | org.codehaus.plexus:plexus-utils:1.5.1 | org.codehaus.plexus:plexus-utils:1.5.1 | [3.0.16] |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/criticalSeverity.png)<br>Critical | org.springframework:spring-aop:2.5.6 | org.springframework:spring-core:2.5.6 | [3.0.0.RELEASE] |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/highSeverity.png)<br>    High | org.apache.commons:commons-email:1.1 | org.apache.commons:commons-email:1.1 | [1.5] |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/mediumSeverity.png)<br>  Medium | commons-io:commons-io:1.4 | commons-io:commons-io:1.4 | [2.7] |
</div>

## Details


<details>
<summary> <b>org.codehaus.plexus:plexus-utils 1.5.1</b> </summary>
<br>

- **Severity:** 💀 Critical
- **Package Name:** org.codehaus.plexus:plexus-utils
- **Current Version:** 1.5.1
- **Fixed Version:** [3.0.16]
- **CVEs:** CVE-2017-1000487

**Description:**

Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.


</details>


<details>
<summary> <b>org.springframework:spring-core 2.5.6</b> </summary>
<br>

- **Severity:** 💀 Critical
- **Package Name:** org.springframework:spring-core
- **Current Version:** 2.5.6
- **Fixed Version:** [3.0.0.RELEASE]
- **CVEs:** CVE-2015-5211

**Description:**

Under some situations, the Spring Framework 4.2.0 to 4.2.1, 4.0.0 to 4.1.7, 3.2.0 to 3.2.14 and older unsupported versions is vulnerable to a Reflected File Download (RFD) attack. The attack involves a malicious user crafting a URL with a batch script extension that results in the response being downloaded rather than rendered and also includes some input reflected in the response.


</details>


<details>
<summary> <b>org.apache.commons:commons-email 1.1</b> </summary>
<br>

- **Severity:** 🔥 High
- **Package Name:** org.apache.commons:commons-email
- **Current Version:** 1.1
- **Fixed Version:** [1.5]
- **CVEs:** CVE-2017-9801

**Description:**

When a call-site passes a subject for an email that contains line-breaks in Apache Commons Email 1.0 through 1.4, the caller can add arbitrary SMTP headers.


</details>


<details>
<summary> <b>commons-io:commons-io 1.4</b> </summary>
<br>

- **Severity:** 🎃 Medium
- **Package Name:** commons-io:commons-io
- **Current Version:** 1.4
- **Fixed Version:** [2.7]
- **CVEs:** CVE-2021-29425

**Description:**

In Apache Commons IO before 2.7, When invoking the method FileNameUtils.normalize with an improper input string, like "//../foo", or "\\..\foo", the result would be the same value, thus possibly providing access to files in the parent directory, but not further above (thus "limited" path traversal), if the calling code would use the result to construct a path value.


</details>

