### PR TITLE
[🐸 Frogbot] Update dependencies versions

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -1,2 +1,2 @@
 pexpect==4.8.0
-pyjwt==1.7.1
+pyjwt==2.4.0


### PR DESCRIPTION

## Summary

<div align="center">

| SEVERITY                | CONTEXTUAL ANALYSIS                  | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                   | FIXED VERSIONS                       |
| :---------------------: | :----------------------------------: | :----------------------------------: | :-----------------------------------: | :---------------------------------: | 
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/highSeverity.png)<br>    High | Undetermined |pyjwt:1.7.1 | pyjwt:1.7.1 | [2.4.0] |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/mediumSeverity.png)<br>  Medium | Undetermined |setuptools:65.5.0 | setuptools:65.5.0 | [65.5.1] |

</div>

## Details


<details>
<summary> <b>pyjwt 1.7.1</b> </summary>
<br>

- **Severity:** 🔥 High
- **Contextual Analysis:** Undetermined
- **Package Name:** pyjwt
- **Current Version:** 1.7.1
- **Fixed Version:** [2.4.0]
- **CVEs:** CVE-2022-29217

**Description:**

[PyJWT](https://pypi.org/project/PyJWT) is a Python implementation of the RFC 7519 standard (JSON Web Tokens). [JSON Web Tokens](https://jwt.io/) are an open, industry standard method for representing claims securely between two parties. A JWT comes with an inline signature that is meant to be verified by the receiving application. JWT supports multiple standard algorithms, and the algorithm itself is **specified in the JWT token itself**.

The PyJWT library uses the signature-verification algorithm that is specified in the JWT token (that is completely attacker-controlled), however - it requires the validating application to pass an `algorithms` kwarg that specifies the expected algorithms in order to avoid key confusion. Unfortunately -  a non-default value `algorithms=jwt.algorithms.get_default_algorithms()` exists that allows all algorithms.
The PyJWT library also tries to mitigate key confusions in this case, by making sure that public keys are not used as an HMAC secret. For example, HMAC secrets that begin with `-----BEGIN PUBLIC KEY-----` are rejected when encoding a JWT.

It has been discovered that due to missing key-type checks, in cases where -
1. The vulnerable application expects to receive a JWT signed with an Elliptic-Curve key (one of the algorithms `ES256`, `ES384`, `ES512`, `EdDSA`)
2. The vulnerable application decodes the JWT token using the non-default kwarg `algorithms=jwt.algorithms.get_default_algorithms()` (or alternatively, `algorithms` contain both an HMAC-based algorithm and an EC-based algorithm)

An attacker can create an HMAC-signed (ex. `HS256`) JWT token, using the (well-known!) EC public key as the HMAC key. The validating application will accept this JWT token as a valid token.

For example, an application might have planned to validate an `EdDSA`-signed token that was generated as follows -
```python
# Making a good jwt token that should work by signing it with the private key
encoded_good = jwt.encode({"test": 1234}, priv_key_bytes, algorithm="EdDSA")
```
An attacker in posession of the public key can generate an `HMAC`-signed token to confuse PyJWT - 
```python
# Using HMAC with the public key to trick the receiver to think that the public key is a HMAC secret
encoded_bad = jwt.encode({"test": 1234}, pub_key_bytes, algorithm="HS256")
```

The following vulnerable `decode` call will accept BOTH of the above tokens as valid - 
```
decoded = jwt.decode(encoded_good, pub_key_bytes, 
algorithms=jwt.algorithms.get_default_algorithms())
```

**Remediation:**

##### Development mitigations

Use a specific algorithm instead of `jwt.algorithms.get_default_algorithms`.
For example, replace the following call - 
`jwt.decode(encoded_jwt, pub_key_bytes, algorithms=jwt.algorithms.get_default_algorithms())`
With -
`jwt.decode(encoded_jwt, pub_key_bytes, algorithms=["ES256"])`


</details>


<details>
<summary> <b>setuptools 65.5.0</b> </summary>
<br>

- **Severity:** 🎃 Medium
- **Contextual Analysis:** Undetermined
- **Package Name:** setuptools
- **Current Version:** 65.5.0
- **Fixed Version:** [65.5.1]
- **CVEs:** CVE-2022-40897

**Description:**

[Setuptools](https://github.com/pypa/setuptools/) is a package for managing Python packages and dependencies, including tools for building and distributing packages, as well as for discovering and managing 3rd party packages available on PyPI.

The `find_external_links` function in the `setuptools.package_index` module is used to find external links that are associated with a package available on the Python Package Index (PyPI). These external links are typically URLs to the package's homepage, documentation, source code repository, and other resources that are related to the package.

The most common scenario of triggering this issue is when running pip with the `--editable` flag. This will cause the vulnerable `find_external_links` function to be invoked

Example of manual usage of `find_external_links` -
```
from setuptools.package_index import PackageIndex
import requests

# Specify the URL of the package page on PyPI
url = 'https://pypi.org/project/requests'

# Use the requests library to retrieve the HTML content of the package page
response = requests.get(url)

# Create an instance of the PackageIndex class
index = PackageIndex()

# Use the find_external_links function to find external links for the package
links = index.find_external_links(url, response.text)

# Print the name and URL of each external link
for link_name, link_url in links:
    print(f'{link_name}: {link_url}')
```
This example will find and print all external links for a package.

To find a specific url, i.e. the tag containing the `rel=` property, the `find_external_links` function uses a Regular Expression (regex). The regex is too not efficient which can lead to ReDoS on specific user inputs.
As a result, a user fetching malicious HTML from a package in PyPI or a custom PackageIndex page may be attacked.

**Remediation:**




</details>

