### PR TITLE
[🐸 Frogbot] Update version of minimist to 1.2.6

### DIFF
--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "lodash": "4.17.19",
-        "minimist": "1.2.5",
+        "minimist": "^1.2.6",
         "protobufjs": "6.11.2",
         "vconsole": "^3.15.0"
       }
@@ -122,9 +122,9 @@
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/mutation-observer": {
       "version": "1.0.3",

--- a/npm/package.json
+++ b/npm/package.json
@@ -19,8 +19,8 @@
   "homepage": "https://github.com/omerzi/npm_example_project#readme",
   "dependencies": {
     "lodash": "4.17.19",
-    "minimist": "1.2.5",
-    "vconsole": "^3.15.0",
-    "protobufjs": "6.11.2"
+    "minimist": "^1.2.6",
+    "protobufjs": "6.11.2",
+    "vconsole": "^3.15.0"
   }
 }


### PR DESCRIPTION
[![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://github.com/jfrog/frogbot#readme)

## 📦 Vulnerable Dependencies 

### ✍️ Summary

<div align="center">

| SEVERITY                | CONTEXTUAL ANALYSIS                  | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                   | FIXED VERSIONS                       |
| :---------------------: | :----------------------------------: | :----------------------------------: | :-----------------------------------: | :---------------------------------: | 
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/notApplicableCritical.png)<br>Critical | $\color{#3CB371}{\textsf{Not Applicable}}$ |minimist:1.2.5 | minimist:1.2.5 | 1.2.6 |

</div>

## 👇 Details




- **Severity:** 💀 Critical
- **Contextual Analysis:** $\color{#3CB371}{\textsf{Not Applicable}}$
- **Package Name:** minimist
- **Current Version:** 1.2.5
- **Fixed Version:** 1.2.6
- **CVEs:** CVE-2021-44906

**Description:**

[Minimist](https://github.com/substack/minimist) is a simple and very popular argument parser. It is used by more than 14 million by Mar 2022. This package developers stopped developing it since April 2020 and its community released a [newer version](https://github.com/meszaros-lajos-gyorgy/minimist-lite) supported by the community.


An incomplete fix for [CVE-2020-7598](https://nvd.nist.gov/vuln/detail/CVE-2020-7598) partially blocked prototype pollution attacks. Researchers discovered that it does not check for constructor functions which means they can be overridden. This behavior can be triggered easily when using it insecurely (which is the common usage). For example:
```
var argv = parse(['--_.concat.constructor.prototype.y', '123']);
t.equal((function(){}).foo, undefined);
t.equal(argv.y, undefined);
```
In this example, `prototype.y`  is assigned with `123` which will be derived to every newly created object. 

This vulnerability can be triggered when the attacker-controlled input is parsed using Minimist without any validation. As always with prototype pollution, the impact depends on the code that follows the attack, but denial of service is almost always guaranteed.

**Remediation:**

##### Development mitigations

Add the `Object.freeze(Object.prototype);` directive once at the beginning of your main JS source code file (ex. `index.js`), preferably after all your `require` directives. This will prevent any changes to the prototype object, thus completely negating prototype pollution attacks.


